### PR TITLE
Fix invalid package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,28 @@
-   "devDependencies": {
--    "tailwindcss": "^3.5.0",
-+    "tailwindcss": "^3.4.4",
-     "postcss": "^8.4.35",
-     "autoprefixer": "^10.4.18",
-     ...
-   }
+{
+  "name": "dealership-assessment-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "recharts": "^2.8.0",
+    "framer-motion": "^10.16.4",
+    "jspdf": "^2.5.0",
+    "xlsx": "^0.18.5",
+    "lucide-react": "^0.328.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.5.2",
+    "vite": "^5.0.9",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.35",
+    "autoprefixer": "^10.4.18"
+  }
+}


### PR DESCRIPTION
## Summary
- restore the original `package.json`
- pin `tailwindcss` to version `^3.4.4`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d210479708331b1e5590b71ee38b6