### PR TITLE
Add export completion overlay

### DIFF
--- a/src/DealershipAssessmentApp.tsx
+++ b/src/DealershipAssessmentApp.tsx
@@ -1,27 +1,68 @@
 
-import React, { useState } from "react";
-import { motion } from "framer-motion";
-import {
-  LineChart, Line, XAxis, YAxis, CartesianGrid,
-  Tooltip, Legend, ResponsiveContainer,
-  RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis,
-} from "recharts";
+import React, { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import { jsPDF } from "jspdf";
 import * as XLSX from "xlsx";
-import {
-  CheckCircle, AlertTriangle, ChevronRight, ChevronLeft,
-  FileText, Download,
-} from "lucide-react";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { CheckCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
-
-/* ... rest of component code trimmed for brevity in this prototype ... */
 
 const DealershipAssessmentApp: React.FC = () => {
   const [sectionIdx, setSectionIdx] = useState(0);
   const [answers, setAnswers] = useState({});
   const [showResults, setShowResults] = useState(false);
-  return <div className="p-4">Prototype placeholder</div>;
+  const [exportComplete, setExportComplete] = useState(false);
+
+  useEffect(() => {
+    if (exportComplete) {
+      const timeout = setTimeout(() => setExportComplete(false), 2000);
+      return () => clearTimeout(timeout);
+    }
+  }, [exportComplete]);
+
+  const handlePDFExport = () => {
+    const doc = new jsPDF();
+    doc.text("Prototype export", 10, 10);
+    doc.save("assessment.pdf");
+    setExportComplete(true);
+  };
+
+  const handleXLSXExport = () => {
+    const ws = XLSX.utils.json_to_sheet([{ example: "data" }]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, "Sheet1");
+    XLSX.writeFile(wb, "assessment.xlsx");
+    setExportComplete(true);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="space-x-4">
+        <Button onClick={handlePDFExport}>Export PDF</Button>
+        <Button onClick={handleXLSXExport}>Export XLSX</Button>
+      </div>
+
+      <AnimatePresence>
+        {exportComplete && (
+          <motion.div
+            key="overlay"
+            className="fixed inset-0 flex items-center justify-center bg-black/50 z-50"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <motion.div
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              exit={{ scale: 0 }}
+              transition={{ duration: 0.5 }}
+            >
+              <CheckCircle className="w-24 h-24 text-green-500" />
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
 };
 
 export default DealershipAssessmentApp;


### PR DESCRIPTION
## Summary
- add exportComplete state for tracking export progress
- display animated checkmark overlay after PDF or XLSX export

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897604014108331b98593fd2194494a