### PR TITLE
Animate buttons and selection icons

### DIFF
--- a/src/DealershipAssessmentApp.tsx
+++ b/src/DealershipAssessmentApp.tsx
@@ -1,27 +1,62 @@
-
 import React, { useState } from "react";
 import { motion } from "framer-motion";
-import {
-  LineChart, Line, XAxis, YAxis, CartesianGrid,
-  Tooltip, Legend, ResponsiveContainer,
-  RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis,
-} from "recharts";
-import { jsPDF } from "jspdf";
-import * as XLSX from "xlsx";
-import {
-  CheckCircle, AlertTriangle, ChevronRight, ChevronLeft,
-  FileText, Download,
-} from "lucide-react";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import { CheckCircle, AlertTriangle } from "lucide-react";
 
-/* ... rest of component code trimmed for brevity in this prototype ... */
+const options = [
+  { value: "yes", label: "Yes", Icon: CheckCircle, color: "#16a34a" },
+  { value: "no", label: "No", Icon: AlertTriangle, color: "#dc2626" },
+];
+
+const hover = { scale: 1.03, rotate: 1 };
+const tap = { scale: 0.97, rotate: -1, opacity: 0.8 };
 
 const DealershipAssessmentApp: React.FC = () => {
-  const [sectionIdx, setSectionIdx] = useState(0);
-  const [answers, setAnswers] = useState({});
-  const [showResults, setShowResults] = useState(false);
-  return <div className="p-4">Prototype placeholder</div>;
+  const [choice, setChoice] = useState<string | null>(null);
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Prototype placeholder</h1>
+
+      <div className="space-y-2">
+        {options.map(({ value, label, Icon, color }) => {
+          const selected = choice === value;
+          return (
+            <motion.button
+              key={value}
+              whileHover={hover}
+              whileTap={tap}
+              onClick={() => setChoice(value)}
+              className="flex items-center gap-2 px-3 py-2 border rounded-md"
+            >
+              <motion.span
+                initial={false}
+                animate={
+                  selected
+                    ? { scale: 1.1, color }
+                    : { scale: 1, color: "#9ca3af" }
+                }
+                transition={{ type: "spring", stiffness: 400, damping: 15 }}
+                className="inline-flex"
+              >
+                <Icon className="w-5 h-5" />
+              </motion.span>
+              {label}
+            </motion.button>
+          );
+        })}
+      </div>
+
+      <motion.button
+        whileHover={hover}
+        whileTap={tap}
+        onClick={() => alert(choice)}
+        className="px-4 py-2 bg-blue-600 text-white rounded-md"
+      >
+        Submit
+      </motion.button>
+    </div>
+  );
 };
 
 export default DealershipAssessmentApp;
+


### PR DESCRIPTION
## Summary
- Replace static buttons with `framer-motion` variants adding hover/tap animations
- Animate answer choice icons with color and scale transitions when selected

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689760496cd883319337ce0b4e195659